### PR TITLE
Parent Span is overwritten by children span #7

### DIFF
--- a/src/main/java/io/opentracing/impl/BraveSpanBuilder.java
+++ b/src/main/java/io/opentracing/impl/BraveSpanBuilder.java
@@ -51,6 +51,7 @@ final class BraveSpanBuilder extends AbstractSpanBuilder implements BraveSpanCon
             brave.serverTracer().setStateCurrentTrace(traceId, parentSpanId, parentParentId, operationName);
         }
         if (null == traceId && null == parentSpanId) {
+            brave.localSpanThreadBinder().setCurrentSpan(null);
             brave.serverTracer().clearCurrentSpan();
         }
 


### PR DESCRIPTION
Uses InheritableServerClientAndLocalSpanState as an immediate solution, despite shortcomings on side-cases.

ref: https://github.com/openzipkin/brave-opentracing/issues/7