### PR TITLE
Ignore case when comparing header names

### DIFF
--- a/src/main/java/io/opentracing/impl/BraveSpanBuilder.java
+++ b/src/main/java/io/opentracing/impl/BraveSpanBuilder.java
@@ -106,7 +106,7 @@ final class BraveSpanBuilder extends AbstractSpanBuilder implements BraveSpanCon
 
     private static BraveHttpHeaders valueOf(String key) {
         for (BraveHttpHeaders header : BraveHttpHeaders.values()) {
-            if (header.getName().equals(key)) {
+            if (header.getName().equalsIgnoreCase(key)) {
                 return header;
             }
         }


### PR DESCRIPTION
This patch updates the test used to detect a B3 header to be
case-insensitive. This helps in contexts where the supplied header
container doesn't have a case insensitive key lookup, such as a
Clojure Ring handler.