### PR TITLE
Ensure OpenTracing's Span.close() calls brave.Span.finish()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave</artifactId>
-            <version>4.0.5</version>
+            <version>4.0.6</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/brave/opentracing/BraveSpan.java
+++ b/src/main/java/brave/opentracing/BraveSpan.java
@@ -79,7 +79,7 @@ public final class BraveSpan implements Span {
      */
     @Override
     public void close() {
-        delegate.close();
+        delegate.finish();
     }
 
     /**

--- a/src/test/java/brave/opentracing/BraveSpanTest.java
+++ b/src/test/java/brave/opentracing/BraveSpanTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.opentracing;
+
+import brave.Tracer;
+import io.opentracing.Span;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BraveSpanTest {
+  List<zipkin.Span> spans = new ArrayList();
+  BraveTracer tracer = BraveTracer.wrap(Tracer.newBuilder().reporter(spans::add).build());
+
+  /** OpenTracing span implements auto-closeable, and implies reporting on close */
+  @Test public void autoCloseOnTryFinally() {
+    try (Span span = tracer.buildSpan("foo").start()) {
+    }
+
+    assertThat(spans).hasSize(1);
+  }
+
+  @Test public void autoCloseOnTryFinally_doesntReportTwice() {
+    try (Span span = tracer.buildSpan("foo").start()) {
+      span.finish(); // user closes and also auto-close closes
+    }
+
+    assertThat(spans).hasSize(1);
+  }
+}


### PR DESCRIPTION
This makes the implementation of close more explicit in the OpenTracing
interface.