### PR TITLE
Comparing HTTP headers in a case-insensitive fashion

### DIFF
--- a/src/main/java/brave/opentracing/BraveTracer.java
+++ b/src/main/java/brave/opentracing/BraveTracer.java
@@ -26,6 +26,9 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+
 
 /**
  * Using a tracer, you can create a spans, inject span contexts into a transport, and extract span contexts from a
@@ -108,30 +111,31 @@ public final class BraveTracer implements Tracer {
 
     /**
      * Eventhough TextMap is named like Map, it doesn't have a retrieve-by-key method
+     * Lookups will be case insensitive
      */
     static final class TextMapView {
         final Iterator<Map.Entry<String, String>> input;
         final Map<String, String> cache = new LinkedHashMap<>();
-        final List<String> fields;
+        final Set<String> fields;
 
         TextMapView(List<String> fields, TextMap input) {
-            this.fields = fields;
             this.input = input.iterator();
+            this.fields = new HashSet<String>();
+            for (String f : fields) {
+                this.fields.add(f.toLowerCase());
+            }
         }
 
         @Nullable
         String get(String key) {
-            String result = cache.get(key);
-            if (result != null) return result;
             while (input.hasNext()) {
                 Map.Entry<String, String> next = input.next();
-                if (next.getKey().equals(key)) {
-                    return next.getValue();
-                } else if (fields.contains(next.getKey())) {
-                    cache.put(next.getKey(), next.getValue());
+                String inputKey = next.getKey().toLowerCase();
+                if (fields.contains(inputKey)) {
+                    cache.put(inputKey, next.getValue());
                 }
             }
-            return null;
+            return cache.get(key.toLowerCase());
         }
     }
 }

--- a/src/test/java/brave/opentracing/BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/BraveTracerTest.java
@@ -85,6 +85,25 @@ public class BraveTracerTest {
     }
 
     @Test
+    public void extractTraceContextCaseInsensitive() throws Exception {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("X-B3-TraceId", "0000000000000001");
+        map.put("x-b3-spanid", "0000000000000002");
+        map.put("x-b3-SaMpLeD", "1");
+        map.put("other", "1");
+
+        BraveSpanContext openTracingContext =
+                (BraveSpanContext) opentracing.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(map));
+
+        assertThat(openTracingContext.unwrap())
+                .isEqualTo(TraceContext.newBuilder()
+                        .traceId(1L)
+                        .spanId(2L)
+                        .shared(true)
+                        .sampled(true).build());
+    }
+
+    @Test
     public void injectTraceContext() throws Exception {
         TraceContext context = TraceContext.newBuilder()
                 .traceId(1L)


### PR DESCRIPTION
Span context propagation fails when HTTP header names are converted to lowercase (e.g. when using spring-boot).

E.g.
- Header sent from client: X-B3-TraceId
- Header obtained from http request object in spring-boot: x-b3-traceid

From RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1"

"Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive"

So, extractor logic should be able to extract context information even if http headers were in different case. Unfortunately, it's not the case, TextMapView::get fails to get header values.

Fix: Updated extractor getter logic (TextMapView) to perform case insensitive lookups in HTTP headers data.