### PR TITLE
Join when starting a server span with a parent

### DIFF
--- a/src/main/java/brave/opentracing/BraveTracer.java
+++ b/src/main/java/brave/opentracing/BraveTracer.java
@@ -24,11 +24,10 @@ import io.opentracing.propagation.TextMap;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
-
 
 /**
  * Using a tracer, you can create a spans, inject span contexts into a transport, and extract span contexts from a
@@ -55,7 +54,7 @@ public final class BraveTracer implements Tracer {
     static final List<String> PROPAGATION_KEYS = Propagation.B3_STRING.keys();
     static final TraceContext.Injector<TextMap> INJECTOR = Propagation.B3_STRING.injector(TextMap::put);
     static final TraceContext.Extractor<TextMapView> EXTRACTOR = Propagation.B3_STRING.extractor(TextMapView::get);
-    static final Set<String> FIELDS_LOWER_CASE = buildHashSetLowerCase(PROPAGATION_KEYS);
+    static final Set<String> FIELDS_LOWER_CASE = lowercaseSet(PROPAGATION_KEYS);
 
     private final brave.Tracer brave4;
 
@@ -106,13 +105,13 @@ public final class BraveTracer implements Tracer {
         TraceContextOrSamplingFlags result =
                 EXTRACTOR.extract(new TextMapView(FIELDS_LOWER_CASE, (TextMap) carrier));
         TraceContext context = result.context() != null
-                ? result.context().toBuilder().shared(true).build()
+                ? result.context()
                 : brave4.newTrace(result.samplingFlags()).context();
         return BraveSpanContext.wrap(context);
     }
 
-    static Set<String> buildHashSetLowerCase(List<String> fields) {
-        Set<String> lcSet = new HashSet<String>();
+    static Set<String> lowercaseSet(List<String> fields) {
+        Set<String> lcSet = new LinkedHashSet<>();
         for (String f : fields) {
             lcSet.add(f.toLowerCase());
         }

--- a/src/test/java/brave/opentracing/BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/BraveTracerTest.java
@@ -80,7 +80,6 @@ public class BraveTracerTest {
                 .isEqualTo(TraceContext.newBuilder()
                         .traceId(1L)
                         .spanId(2L)
-                        .shared(true)
                         .sampled(true).build());
     }
 
@@ -98,7 +97,6 @@ public class BraveTracerTest {
                 .isEqualTo(TraceContext.newBuilder()
                         .traceId(1L)
                         .spanId(2L)
-                        .shared(true)
                         .sampled(true).build());
     }
 
@@ -117,7 +115,6 @@ public class BraveTracerTest {
                 .isEqualTo(TraceContext.newBuilder()
                         .traceId(1L)
                         .spanId(2L)
-                        .shared(true)
                         .sampled(true).build());
     }
 


### PR DESCRIPTION
This replicates the same behavior as exists in zipkin-go-opentracing.
We support adding "span.kind" before a span is started. By doing so, we
can properly decide whether to join a span or start a remote child.

This rewrites the unit tests so that we can ensure dependency links
work, too. The tests were taken from #27.

Closes #27