### PR TITLE
Updates to use tracing component, allowing you to switch propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Firstly, you need a Tracer, configured to [report to Zipkin](https://github.com/
 sender = OkHttpSender.create("http://127.0.0.1:9411/api/v1/spans");
 reporter = AsyncReporter.builder(sender).build();
 
-// Now, create a Brave tracer with the service name you want to see in Zipkin.
+// Now, create a Brave tracing component with the service name you want to see in Zipkin.
 //   (the dependency is io.zipkin.brave:brave)
-braveTracer = Tracer.newBuilder()
-                    .localServiceName("my-service")
-                    .reporter(reporter)
-                    .build();
+braveTracing = Tracing.newBuilder()
+                      .localServiceName("my-service")
+                      .reporter(reporter)
+                      .build();
 
-// Finally, wrap this with the OpenTracing Api
-tracer = BraveTracer.wrap(braveTracer);
+// use this to create an OpenTracing Tracer
+tracer = BraveTracer.create(braveTracing);
 
 // You can later unwrap the underlying Brave Api as needed
 braveTracer = tracer.unwrap();

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
-      <version>4.0.6</version>
+      <version>4.2.0</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/brave/opentracing/BraveSpanTest.java
+++ b/src/test/java/brave/opentracing/BraveSpanTest.java
@@ -13,7 +13,7 @@
  */
 package brave.opentracing;
 
-import brave.Tracer;
+import brave.Tracing;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
@@ -35,8 +35,8 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class BraveSpanTest {
   InMemoryStorage zipkin = new InMemoryStorage();
-  BraveTracer tracer = BraveTracer.wrap(
-      Tracer.newBuilder()
+  BraveTracer tracer = BraveTracer.create(
+      Tracing.newBuilder()
           .localServiceName("tracer")
           .reporter(s -> zipkin.spanConsumer().accept(Collections.singletonList(s))).build()
   );
@@ -110,8 +110,8 @@ public class BraveSpanTest {
     Map<String, String> carrier = new LinkedHashMap<>();
     tracer.inject(spanClient.context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(carrier));
 
-    BraveTracer tracer2 = BraveTracer.wrap(
-        Tracer.newBuilder()
+    BraveTracer tracer2 = BraveTracer.create(
+        Tracing.newBuilder()
             .localServiceName("tracer2")
             .reporter(s -> zipkin.spanConsumer().accept(Collections.singletonList(s))).build()
     );

--- a/src/test/java/brave/opentracing/BraveTracerTest.java
+++ b/src/test/java/brave/opentracing/BraveTracerTest.java
@@ -13,7 +13,7 @@
  */
 package brave.opentracing;
 
-import brave.Tracer;
+import brave.Tracing;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import io.opentracing.propagation.Format;
@@ -39,8 +39,8 @@ import static zipkin.internal.Util.UTF_8;
 public class BraveTracerTest {
 
   List<zipkin.Span> spans = new ArrayList<>();
-  Tracer brave = Tracer.newBuilder().reporter(spans::add).build();
-  BraveTracer opentracing = BraveTracer.wrap(brave);
+  Tracing brave = Tracing.newBuilder().reporter(spans::add).build();
+  BraveTracer opentracing = BraveTracer.create(brave);
 
   @Test public void startWithOpenTracingAndFinishWithBrave() {
     io.opentracing.Span openTracingSpan = opentracing.buildSpan("encode")
@@ -56,7 +56,7 @@ public class BraveTracerTest {
   }
 
   @Test public void startWithBraveAndFinishWithOpenTracing() {
-    brave.Span braveSpan = brave.newTrace().name("encode")
+    brave.Span braveSpan = brave.tracer().newTrace().name("encode")
         .tag(Constants.LOCAL_COMPONENT, "codec")
         .start(1L);
 


### PR DESCRIPTION
The latest version of Brave includes a tracing component which provides
the propagation implementation. This removes the hard-coding.

Note: this breaks the BraveTracer.wrap() signature because this library
is <1.0 and doesn't need the complexity of deprecation.