### PR TITLE
Only do Zipkin-style span join if the parent is willing to be shared

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,21 @@
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
       <version>4.5.1</version>
+
+      <!-- TODO: remove exclusion and explicit dependency on zipkin:1.29.0 once
+        brave releases a new version that depends on zipkin >= 1.29.0. -->
+      <exclusions>
+        <exclusion>
+          <groupId>io.zipkin.java</groupId>
+          <artifactId>zipkin</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>1.29.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/brave/opentracing/BraveSpanBuilder.java
+++ b/src/main/java/brave/opentracing/BraveSpanBuilder.java
@@ -130,7 +130,7 @@ public final class BraveSpanBuilder implements Tracer.SpanBuilder {
         }
       }
       span = braveTracer.newTrace(samplingFlags);
-    } else if (server) {
+    } else if (server && parent.shared()) {
       // Zipkin's default is to share a span ID between the client and the server in an RPC.
       // When we start a server span with a parent, we assume the "parent" is actually the
       // client on the other side of the RPC. Accordingly, we join that span instead of fork.

--- a/src/test/java/brave/opentracing/BraveSpanTest.java
+++ b/src/test/java/brave/opentracing/BraveSpanTest.java
@@ -102,7 +102,7 @@ public class BraveSpanTest {
         .containsExactly(tuple("hello", "monster"));
   }
 
-  @Test public void shareSpanWhenParentIsExtracted() {
+  @Test public void childSpanWhenParentIsExtracted() {
     Span spanClient = tracer.buildSpan("foo")
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
         .start();
@@ -136,7 +136,7 @@ public class BraveSpanTest {
     assertThat(spans).hasSize(3);
     assertThat(spans.get(0).traceId).isEqualTo(spans.get(1).traceId)
         .isEqualTo(spans.get(2).traceId);
-    assertThat(spans.get(1).id).isEqualTo(spans.get(2).id);
+    assertThat(spans.get(1).id).isNotEqualTo(spans.get(2).id);
     assertThat(spans.get(0).id).isNotEqualTo(spans.get(1).id);
 
     assertThat(zipkin.spanStore().getDependencies(System.currentTimeMillis(), null))


### PR DESCRIPTION
When the span is of kind `SPAN_KIND_SERVER`, we only want to join with the
parent span (from the client) if that span's context declares that the
span is willing to be shared. Otherwise, create a new child span for the
server side of the RPC.

Signed-off-by: Maxime Petazzoni <maxime.petazzoni@bulix.org>